### PR TITLE
Localize About modal titles

### DIFF
--- a/app/components/AboutModal.tsx
+++ b/app/components/AboutModal.tsx
@@ -1,6 +1,7 @@
 import Button from "./Button";
 import { Stack, Modal } from "react-bootstrap";
 import { open } from "@tauri-apps/plugin-shell";
+import { useT } from "@/app/i18n";
 
 export default function AboutModal({
   show,
@@ -13,13 +14,16 @@ export default function AboutModal({
   name: string;
   version: string;
 }) {
+  const t = useT();
   return (
     <Modal show={show} onHide={() => setShow(false)} centered={true}>
       <Modal.Header>
-        <Modal.Title>About {name}</Modal.Title>
+        <Modal.Title>{t("About {name}").replace("{name}", name)}</Modal.Title>
       </Modal.Header>
       <Modal.Body>
-        <p className="font-monospace">Version {version}</p>
+        <p className="font-monospace">
+          {t("Version {version}").replace("{version}", version)}
+        </p>
         <p>
           ©2020-2025 OpenFusion Contributors
           <br />

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -5,6 +5,8 @@
   "Delete server": "Delete server",
   "Connect": "Connect",
   "About OpenFusion Launcher": "About OpenFusion Launcher",
+  "About {name}": "About {name}",
+  "Version {version}": "Version {version}",
   "Settings": "Settings",
   "Welcome to OpenFusion.\nSelect a server from the list below to get started.": "Welcome to OpenFusion.\nSelect a server from the list below to get started.",
   "Launcher Settings": "Launcher Settings",

--- a/app/locales/ru.json
+++ b/app/locales/ru.json
@@ -5,6 +5,8 @@
   "Delete server": "Удалить сервер",
   "Connect": "Подключиться",
   "About OpenFusion Launcher": "О программе OpenFusion Launcher",
+  "About {name}": "О программе {name}",
+  "Version {version}": "Версия {version}",
   "Settings": "Настройки",
   "Welcome to OpenFusion.\nSelect a server from the list below to get started.": "Добро пожаловать в OpenFusion.\nВыберите сервер из списка ниже, чтобы начать.",
   "Launcher Settings": "Настройки лаунчера",


### PR DESCRIPTION
## Summary
- localize About modal strings with placeholders for name and version
- add translation keys for the localized placeholders in English and Russian locales

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glob pattern ../resources/ffrunner/loader/* path not found or didn't match any files)*


------
https://chatgpt.com/codex/tasks/task_e_688d12603b8083259c642158e8965726