### PR TITLE
feat: translate toast variant labels

### DIFF
--- a/app/components/Toast.tsx
+++ b/app/components/Toast.tsx
@@ -3,10 +3,12 @@ import { useState } from "react";
 import { open } from "@tauri-apps/plugin-shell";
 import { Alert } from "@/app/types";
 import { getHostnameFromLink, variantToLabel } from "@/app/util";
+import { useT } from "@/app/i18n";
 import Button from "./Button";
 
 export default function Toast({ alert }: { alert: Alert }) {
   const [show, setShow] = useState(true);
+  const t = useT();
 
   return (
     <_Toast
@@ -18,7 +20,7 @@ export default function Toast({ alert }: { alert: Alert }) {
       onClose={() => setShow(false)}
     >
       <_Toast.Header>
-        <strong className="me-auto">{variantToLabel(alert.variant)}</strong>
+        <strong className="me-auto">{variantToLabel(alert.variant, t)}</strong>
       </_Toast.Header>
       <_Toast.Body className={"rounded-bottom btn-" + alert.variant}>
         {alert.text}

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -79,6 +79,10 @@
   "Are you sure?": "Are you sure?",
   "Do you really want to delete {server}?": "Do you really want to delete {server}?",
   "You could always re-add it later.": "You could always re-add it later.",
+  "Success": "Success",
+  "Error": "Error",
+  "Warning": "Warning",
+  "Info": "Info",
   "Language": "Language",
   "api.myserver.xyz": "api.myserver.xyz"
 }

--- a/app/locales/ru.json
+++ b/app/locales/ru.json
@@ -79,6 +79,10 @@
   "Are you sure?": "Вы уверены?",
   "Do you really want to delete {server}?": "Вы действительно хотите удалить {server}?",
   "You could always re-add it later.": "Вы всегда можете добавить его снова.",
+  "Success": "Успех",
+  "Error": "Ошибка",
+  "Warning": "Предупреждение",
+  "Info": "Информация",
   "Language": "Язык",
   "api.myserver.xyz": "api.myserver.xyz"
 }

--- a/app/util.ts
+++ b/app/util.ts
@@ -52,16 +52,16 @@ export function getTheme(config: Config) {
   return "dark";
 }
 
-export function variantToLabel(variant: string) {
+export function variantToLabel(variant: string, t: (key: string) => string) {
   switch (variant) {
     case "success":
-      return "Success";
+      return t("Success");
     case "danger":
-      return "Error";
+      return t("Error");
     case "warning":
-      return "Warning";
+      return t("Warning");
     case "primary":
-      return "Info";
+      return t("Info");
     default:
       return "";
   }


### PR DESCRIPTION
## Summary
- translate toast variant headers via i18n lookup
- add English and Russian locale strings for common alert variants

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_688d1268ee948325b6e27794ccd47561