### PR TITLE
Localize default option label

### DIFF
--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -80,5 +80,6 @@
   "Do you really want to delete {server}?": "Do you really want to delete {server}?",
   "You could always re-add it later.": "You could always re-add it later.",
   "Language": "Language",
-  "api.myserver.xyz": "api.myserver.xyz"
+  "api.myserver.xyz": "api.myserver.xyz",
+  "default": "default"
 }

--- a/app/locales/ru.json
+++ b/app/locales/ru.json
@@ -80,5 +80,6 @@
   "Do you really want to delete {server}?": "Вы действительно хотите удалить {server}?",
   "You could always re-add it later.": "Вы всегда можете добавить его снова.",
   "Language": "Язык",
-  "api.myserver.xyz": "api.myserver.xyz"
+  "api.myserver.xyz": "api.myserver.xyz",
+  "default": "по умолчанию"
 }

--- a/app/settings/SettingControlDropdown.tsx
+++ b/app/settings/SettingControlDropdown.tsx
@@ -2,6 +2,7 @@ import { SettingsOption } from "@/app/types";
 import { Form } from "react-bootstrap";
 import SettingControlBase from "./SettingControlBase";
 import { useEffect, useState } from "react";
+import { useT } from "@/app/i18n";
 
 export default function SettingControlDropdown({
   id,
@@ -20,6 +21,7 @@ export default function SettingControlDropdown({
   defaultKey: string;
   onChange: (value: any) => void;
 }) {
+  const t = useT();
   const getOptionValueFromKey = (key: string) => {
     const option = options.find((option) => option.key === key);
     if (!option) {
@@ -65,7 +67,7 @@ export default function SettingControlDropdown({
           <option key={option.key} value={option.key}>
             {option.label +
               (option.description ? " - " + option.description : "") +
-              (option.key === defaultKey ? " (default)" : "")}
+              (option.key === defaultKey ? ` (${t("default")})` : "")}
           </option>
         ))}
       </Form.Select>


### PR DESCRIPTION
## Summary
- replace hard coded "(default)" in settings dropdown with t("default")
- add "default" entry to English and Russian translations

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glob pattern ../resources/ffrunner/player/fusion-2.x.x/* path not found or didn't match any files)*

------
https://chatgpt.com/codex/tasks/task_e_688d127829fc8325922341831dbc0393