### PR TITLE
feat: localize dialog file filter

### DIFF
--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -46,6 +46,7 @@
   "Close": "Close",
   "Remove and Clear Caches": "Remove and Clear Caches",
   "Remove": "Remove",
+  "File": "File",
   "Browse...": "Browse...",
   "Add Build": "Add Build",
   "Clear All Game": "Clear All Game",

--- a/app/locales/ru.json
+++ b/app/locales/ru.json
@@ -46,6 +46,7 @@
   "Close": "Закрыть",
   "Remove and Clear Caches": "Удалить и очистить кэши",
   "Remove": "Удалить",
+  "File": "Файл",
   "Browse...": "Обзор...",
   "Add Build": "Добавить сборку",
   "Clear All Game": "Очистить игру",

--- a/app/settings/SettingControlBrowse.tsx
+++ b/app/settings/SettingControlBrowse.tsx
@@ -3,6 +3,7 @@ import SettingControlBase from "./SettingControlBase";
 import { useEffect, useState } from "react";
 import Button from "@/components/Button";
 import { open } from "@tauri-apps/plugin-dialog";
+import { useT } from "@/i18n";
 
 export default function SettingControlBrowse({
   id,
@@ -26,6 +27,7 @@ export default function SettingControlBrowse({
   onChange: (value: string) => void;
 }) {
   const [text, setText] = useState<string>(value ?? "");
+  const t = useT();
 
   const oldValueString = oldValue ?? "";
   const valueString = value ?? "";
@@ -51,7 +53,7 @@ export default function SettingControlBrowse({
         ? []
         : [
             {
-              name: "File",
+              name: t("File"),
               extensions: extensions ?? ["*"],
             },
           ],


### PR DESCRIPTION
## Summary
- translate file dialog filter label using locale key

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glob pattern ../resources/ffrunner/mono/fusion-2.x.x/* path not found or didn't match any files)*

------
https://chatgpt.com/codex/tasks/task_e_688d127924b483259fe49e50aae57b38