### PR TITLE
Localize FPS fix control text

### DIFF
--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -80,5 +80,12 @@
   "Do you really want to delete {server}?": "Do you really want to delete {server}?",
   "You could always re-add it later.": "You could always re-add it later.",
   "Language": "Language",
-  "api.myserver.xyz": "api.myserver.xyz"
+  "api.myserver.xyz": "api.myserver.xyz",
+  "FusionFall's framerate is normally capped around 64 FPS.": "FusionFall's framerate is normally capped around 64 FPS.",
+  "This setting activates a patch to remove this limit.": "This setting activates a patch to remove this limit.",
+  "You can restore the original behavior by turning it off or tweak it to your own soft cap.": "You can restore the original behavior by turning it off or tweak it to your own soft cap.",
+  "On (experimental, default)": "On (experimental, default)",
+  "On with limiter": "On with limiter",
+  "Off": "Off",
+  "FPS": "FPS"
 }

--- a/app/locales/ru.json
+++ b/app/locales/ru.json
@@ -80,5 +80,12 @@
   "Do you really want to delete {server}?": "Вы действительно хотите удалить {server}?",
   "You could always re-add it later.": "Вы всегда можете добавить его снова.",
   "Language": "Язык",
-  "api.myserver.xyz": "api.myserver.xyz"
+  "api.myserver.xyz": "api.myserver.xyz",
+  "FusionFall's framerate is normally capped around 64 FPS.": "Частота кадров FusionFall обычно ограничена около 64 FPS.",
+  "This setting activates a patch to remove this limit.": "Эта настройка активирует патч, снимающий это ограничение.",
+  "You can restore the original behavior by turning it off or tweak it to your own soft cap.": "Вы можете восстановить исходное поведение, выключив настройку, или задать собственный мягкий предел.",
+  "On (experimental, default)": "Вкл. (экспериментально, по умолчанию)",
+  "On with limiter": "Вкл. с ограничителем",
+  "Off": "Выкл.",
+  "FPS": "FPS"
 }

--- a/app/settings/SettingControlFpsFix.tsx
+++ b/app/settings/SettingControlFpsFix.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Form } from "react-bootstrap";
 import SettingControlBase from "./SettingControlBase";
 import { FpsFix, FpsLimit } from "@/app/types";
+import { useT } from "@/app/i18n";
 
 const KEY_FIX_ON = "on";
 const KEY_FIX_ON_WITH_LIMITER = "on_with_limiter";
@@ -49,6 +50,7 @@ export default function SettingControlFpsFix({
   const [fpsLimit, setFpsLimit] = useState<string>(
     getFpsLimitForValue(value)?.toString() ?? "",
   );
+  const t = useT();
 
   const updateOuter = (key: string, fpsLimit?: string) => {
     if (key === KEY_FIX_ON) {
@@ -81,9 +83,11 @@ export default function SettingControlFpsFix({
     : getFpsLimitForValue(value) !== getFpsLimitForValue(oldValue);
 
   const EXPLANATION = [
-    "FusionFall's framerate is normally capped around 64 FPS.",
-    "This setting activates a patch to remove this limit.",
-    "You can restore the original behavior by turning it off or tweak it to your own soft cap.",
+    t("FusionFall's framerate is normally capped around 64 FPS."),
+    t("This setting activates a patch to remove this limit."),
+    t(
+      "You can restore the original behavior by turning it off or tweak it to your own soft cap.",
+    ),
   ];
 
   return (
@@ -92,7 +96,7 @@ export default function SettingControlFpsFix({
       <Form.Check
         type="radio"
         id={`${id}-on`}
-        label="On (experimental, default)"
+        label={t("On (experimental, default)")}
         checked={selected === KEY_FIX_ON}
         className={selected === KEY_FIX_ON && keyModified ? "text-success" : ""}
         onChange={() => {
@@ -104,7 +108,7 @@ export default function SettingControlFpsFix({
         <Form.Check
           type="radio"
           id={`${id}-on-with-limiter`}
-          label="On with limiter"
+          label={t("On with limiter")}
           checked={selected === KEY_FIX_ON_WITH_LIMITER}
           className={
             selected === KEY_FIX_ON_WITH_LIMITER && keyModified
@@ -128,12 +132,12 @@ export default function SettingControlFpsFix({
             updateOuter(KEY_FIX_ON_WITH_LIMITER, e.target.value);
           }}
         />
-        <span className="mx-2">FPS</span>
+        <span className="mx-2">{t("FPS")}</span>
       </div>
       <Form.Check
         type="radio"
         id={`${id}-off`}
-        label="Off"
+        label={t("Off")}
         checked={selected === KEY_FIX_OFF}
         className={
           selected === KEY_FIX_OFF && keyModified ? "text-success" : ""


### PR DESCRIPTION
## Summary
- wrap FPS fix explanation, options, and suffix in translation helper
- add English and Russian locale entries for new strings

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: resource path `../resources/ffrunner/d3d9_vulkan.dll` doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_688d127a8f38832589e8659a79849e86