### PR TITLE
fix: remove duplicate useT imports

### DIFF
--- a/app/settings/AuthenticationList.tsx
+++ b/app/settings/AuthenticationList.tsx
@@ -5,11 +5,9 @@ import {
   getBackgroundImageUrlForServer,
   getLogoImageUrlForServer,
 } from "@/app/util";
-import { useT } from "@/app/i18n";
 import { invoke } from "@tauri-apps/api/core";
 import { CSSProperties, useContext, useEffect, useState } from "react";
 import { SettingsCtx } from "@/app/contexts";
-import { useT } from "@/app/i18n";
 import LoginModal from "@/components/LoginModal";
 import ForgotPasswordModal from "@/components/ForgotPasswordModal";
 import ManageAccountModal from "./ManageAccountModal";
@@ -35,7 +33,6 @@ function ListEntry({
   const [showManageAccountModal, setShowManageAccountModal] = useState(false);
 
   const ctx = useContext(SettingsCtx);
-  const t = useT();
 
   const loadSession = async () => {
     setOffline(undefined);


### PR DESCRIPTION
## Summary
- fix duplicated `useT` hooks in `AuthenticationList`

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d2d3b15ec832581d497e20fde0766