### PR TITLE
Localize loading text

### DIFF
--- a/app/components/Button.tsx
+++ b/app/components/Button.tsx
@@ -32,7 +32,7 @@ export default function Button({
 
   const iconElement = loading ? (
     <div className="spinner-border spinner-border-sm" role="status">
-      <span className="visually-hidden">Loading...</span>
+      <span className="visually-hidden">{t("Loading...")}</span>
     </div>
   ) : (
     <i className={"fa" + iconStyleClass + " fa-" + icon}></i>

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -165,5 +165,5 @@
   "Send Temporary Password": "Send Temporary Password",
   "Select Game Version": "Select Game Version",
   "The server {server} supports multiple game versions. Please select a version to use.": "The server {server} supports multiple game versions. Please select a version to use."
-
+  "Loading...": "Loading..."
 }

--- a/app/locales/ru.json
+++ b/app/locales/ru.json
@@ -164,5 +164,6 @@
   "Email": "Электронная почта",
   "Send Temporary Password": "Отправить временный пароль",
   "Select Game Version": "Выберите версию игры",
-  "The server {server} supports multiple game versions. Please select a version to use.": "Сервер {server} поддерживает несколько версий игры. Пожалуйста, выберите используемую версию."
+  "The server {server} supports multiple game versions. Please select a version to use.": "Сервер {server} поддерживает несколько версий игры. Пожалуйста, выберите используемую версию.",
+  "Loading...": "Загрузка..."
 }


### PR DESCRIPTION
## Summary
- wrap button loading placeholder with translation
- add `Loading...` text to English and Russian locales

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: resource path `../resources/ffrunner/ffrunner.exe` doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_688d3a4bba1c83259d62240b3b7607b2