### PR TITLE
feat: localize logo alt text

### DIFF
--- a/app/components/LogoImages.tsx
+++ b/app/components/LogoImages.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import { ServerEntry } from "@/app/types";
 import { getLogoImageUrlForServer } from "@/app/util";
 import NextImage from "next/image";
+import { useT } from "@/app/i18n";
 
 export default function BackgroundImages({
   servers,
@@ -15,6 +16,7 @@ export default function BackgroundImages({
 }) {
   // map of server UUIDs to bools indicating whether the image is loaded
   const [loadedImages, setLoadedImages] = useState<Record<string, boolean>>({});
+  const t = useT();
 
   const isImageLoaded = (server: ServerEntry) => {
     return loadedImages[server.uuid] || false;
@@ -41,7 +43,7 @@ export default function BackgroundImages({
         <img
           src={imageUrl}
           className="logo-image"
-          alt={selectedServer.description + " Logo"}
+          alt={t("{server} Logo").replace("{server}", selectedServer.description)}
         />
       </div>
     );
@@ -52,13 +54,13 @@ export default function BackgroundImages({
       <NextImage
         id="of-logo-light"
         src={ofLogoLight}
-        alt="OpenFusion Logo"
+        alt={t("OpenFusion Logo")}
         width={256}
       />
       <NextImage
         id="of-logo-dark"
         src={ofLogoDark}
-        alt="OpenFusion Logo"
+        alt={t("OpenFusion Logo")}
         width={256}
       />
     </>

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -163,6 +163,8 @@
   "Once you have logged in, you can change your password in Settings -> Authentication -> Manage Account -> Change Password.": "Once you have logged in, you can change your password in Settings -> Authentication -> Manage Account -> Change Password.",
   "Email": "Email",
   "Send Temporary Password": "Send Temporary Password",
+  "{server} Logo": "{server} Logo",
+  "OpenFusion Logo": "OpenFusion Logo",
   "Select Game Version": "Select Game Version",
   "The server {server} supports multiple game versions. Please select a version to use.": "The server {server} supports multiple game versions. Please select a version to use."
   "Loading...": "Loading..."

--- a/app/locales/ru.json
+++ b/app/locales/ru.json
@@ -163,6 +163,8 @@
   "Once you have logged in, you can change your password in Settings -> Authentication -> Manage Account -> Change Password.": "После входа вы можете изменить пароль в Настройки -> Аутентификация -> Управление аккаунтом -> Изменить пароль.",
   "Email": "Электронная почта",
   "Send Temporary Password": "Отправить временный пароль",
+  "{server} Logo": "Логотип {server}",
+  "OpenFusion Logo": "Логотип OpenFusion",
   "Select Game Version": "Выберите версию игры",
   "The server {server} supports multiple game versions. Please select a version to use.": "Сервер {server} поддерживает несколько версий игры. Пожалуйста, выберите используемую версию.",
   "Loading...": "Загрузка..."


### PR DESCRIPTION
## Summary
- localize server and default logo alt text using translation hook
- add English and Russian translations for new alt text keys

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glob pattern ../resources/ffrunner/player/fusion-2.x.x/Data/* path not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d42071d808325a4e4b8ab0c9fbab6