### PR TITLE
Localize file filter label in browse setting

### DIFF
--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -53,6 +53,7 @@
   "Remove and Clear Caches": "Remove and Clear Caches",
   "Remove": "Remove",
   "Browse...": "Browse...",
+  "File": "File",
   "Add Build": "Add Build",
   "Clear All Game": "Clear All Game",
   "Delete All Offline": "Delete All Offline",
@@ -172,6 +173,6 @@
   "{server} Logo": "{server} Logo",
   "OpenFusion Logo": "OpenFusion Logo",
   "Select Game Version": "Select Game Version",
-  "The server {server} supports multiple game versions. Please select a version to use.": "The server {server} supports multiple game versions. Please select a version to use."
+  "The server {server} supports multiple game versions. Please select a version to use.": "The server {server} supports multiple game versions. Please select a version to use.",
   "Loading...": "Loading..."
 }

--- a/app/locales/ru.json
+++ b/app/locales/ru.json
@@ -53,6 +53,7 @@
   "Remove and Clear Caches": "Удалить и очистить кэши",
   "Remove": "Удалить",
   "Browse...": "Обзор...",
+  "File": "Файл",
   "Add Build": "Добавить сборку",
   "Clear All Game": "Очистить игру",
   "Delete All Offline": "Удалить офлайн",

--- a/app/settings/SettingControlBrowse.tsx
+++ b/app/settings/SettingControlBrowse.tsx
@@ -3,6 +3,7 @@ import SettingControlBase from "./SettingControlBase";
 import { useEffect, useState } from "react";
 import Button from "@/components/Button";
 import { open } from "@tauri-apps/plugin-dialog";
+import { useT } from "@/app/i18n";
 
 export default function SettingControlBrowse({
   id,
@@ -25,6 +26,7 @@ export default function SettingControlBrowse({
   validator?: (value: string) => boolean;
   onChange: (value: string) => void;
 }) {
+  const t = useT();
   const [text, setText] = useState<string>(value ?? "");
 
   const oldValueString = oldValue ?? "";
@@ -51,7 +53,7 @@ export default function SettingControlBrowse({
         ? []
         : [
             {
-              name: "File",
+              name: t("File"),
               extensions: extensions ?? ["*"],
             },
           ],


### PR DESCRIPTION
## Summary
- use translation hook for file dialog filter name in `SettingControlBrowse`
- add `File` key to English and Russian locales

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: resource path `../resources/ffrunner/ffrunner.exe` doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_688dceac49348325bf5ece5470971ae1