### PR TITLE
Translate default label in dropdown settings

### DIFF
--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -156,6 +156,7 @@
   "logged in as": "logged in as",
   "Could not load account information": "Could not load account information",
   "Current email": "Current email",
+  "(default)": "(default)",
   "(not set)": "(not set)",
   "Change Email": "Change Email",
   "New Email": "New Email",

--- a/app/locales/ru.json
+++ b/app/locales/ru.json
@@ -156,6 +156,7 @@
   "logged in as": "вход выполнен как",
   "Could not load account information": "Не удалось загрузить информацию об аккаунте",
   "Current email": "Текущий email",
+  "(default)": "(по умолчанию)",
   "(not set)": "(не указан)",
   "Change Email": "Изменить email",
   "New Email": "Новый email",

--- a/app/settings/SettingControlDropdown.tsx
+++ b/app/settings/SettingControlDropdown.tsx
@@ -2,6 +2,7 @@ import { SettingsOption } from "@/app/types";
 import { Form } from "react-bootstrap";
 import SettingControlBase from "./SettingControlBase";
 import { useEffect, useState } from "react";
+import { useT } from "@/app/i18n";
 
 export default function SettingControlDropdown({
   id,
@@ -20,6 +21,7 @@ export default function SettingControlDropdown({
   defaultKey: string;
   onChange: (value: any) => void;
 }) {
+  const t = useT();
   const getOptionValueFromKey = (key: string) => {
     const option = options.find((option) => option.key === key);
     if (!option) {
@@ -65,7 +67,7 @@ export default function SettingControlDropdown({
           <option key={option.key} value={option.key}>
             {option.label +
               (option.description ? " - " + option.description : "") +
-              (option.key === defaultKey ? " (default)" : "")}
+              (option.key === defaultKey ? ` ${t("(default)")}` : "")}
           </option>
         ))}
       </Form.Select>


### PR DESCRIPTION
## Summary
- localize dropdown default marker using translation function
- add `(default)` key to English and Russian locale files

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glob pattern ../resources/ffrunner/mono/fusion-2.x.x/Data/etc/mono/2.0/* path not found)*

------
https://chatgpt.com/codex/tasks/task_e_688dd1c2e978832580ffd13793ca4d3d