### PR TITLE
Localize authentication log-out messaging

### DIFF
--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -127,6 +127,8 @@
   "Logged in successfully": "Logged in successfully",
   "Verification email sent to {email}": "Verification email sent to {email}",
   "Password updated successfully": "Password updated successfully",
+  "Failed to log out of all game servers: {error}": "Failed to log out of all game servers: {error}",
+  "Are you sure you want to log out of all game servers?": "Are you sure you want to log out of all game servers?",
   "Logged out of all game servers": "Logged out of all game servers",
   "Game cache for {name} cleared successfully": "Game cache for {name} cleared successfully",
   "Game cache cleared successfully": "Game cache cleared successfully",

--- a/app/locales/ru.json
+++ b/app/locales/ru.json
@@ -127,6 +127,8 @@
   "Logged in successfully": "Вход выполнен успешно",
   "Verification email sent to {email}": "Письмо для подтверждения отправлено на {email}",
   "Password updated successfully": "Пароль успешно обновлен",
+  "Failed to log out of all game servers: {error}": "Не удалось выйти из всех игровых серверов: {error}",
+  "Are you sure you want to log out of all game servers?": "Вы действительно хотите выйти из всех игровых серверов?",
   "Logged out of all game servers": "Вы вышли из всех игровых серверов",
   "Game cache for {name} cleared successfully": "Кэш игры для {name} успешно очищен",
   "Game cache cleared successfully": "Кэш игры успешно очищен",

--- a/app/settings/AuthenticationTab.tsx
+++ b/app/settings/AuthenticationTab.tsx
@@ -28,7 +28,12 @@ export default function AuthenticationTab({ active }: { active: boolean }) {
       refresh();
     } catch (e) {
       if (ctx.alertError) {
-        ctx.alertError("Failed to log out of all game servers: " + e);
+        ctx.alertError(
+          t("Failed to log out of all game servers: {error}").replace(
+            "{error}",
+            "" + e,
+          ),
+        );
       }
     }
   };
@@ -68,8 +73,8 @@ export default function AuthenticationTab({ active }: { active: boolean }) {
           onClick={() => {
             if (ctx.showConfirmationModal) {
               ctx.showConfirmationModal(
-                "Are you sure you want to log out of all game servers?",
-                "Log Out All",
+                t("Are you sure you want to log out of all game servers?"),
+                t("Log Out All"),
                 "danger",
                 logOutAll,
               );


### PR DESCRIPTION
## Summary
- localize error message and confirmation prompt for logging out of all game servers
- add English and Russian translations for these messages

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: resource path `../resources/ffrunner/d3d9_vulkan.dll` doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_688dd440c1588325b345f8b9f5269f70