### PR TITLE
fix: load language on startup

### DIFF
--- a/app/i18n.tsx
+++ b/app/i18n.tsx
@@ -23,14 +23,23 @@ export function LanguageProvider({ children }: { children: React.ReactNode }) {
   const [lang, setLang] = useState<Language>("en");
 
   useEffect(() => {
-    const stored = window.localStorage.getItem("lang") as Language | null;
-    if (stored) {
-      setLang(stored);
-    } else {
-      invoke<{ launcher: { language: Language } }>("get_config")
-        .then((cfg) => setLang(cfg.launcher.language))
-        .catch(() => {});
-    }
+    const init = async () => {
+      const stored = window.localStorage.getItem("lang") as Language | null;
+      if (stored) {
+        setLang(stored);
+      } else {
+        try {
+          await invoke("reload_state");
+          const cfg = await invoke<{ launcher: { language: Language } }>(
+            "get_config",
+          );
+          setLang(cfg.launcher.language);
+        } catch {
+          // ignore errors
+        }
+      }
+    };
+    init();
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- initialize stored language during startup by reloading state and reading config

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glob pattern ../resources/ffrunner/mono/fusion-2.x.x/Data/lib/* path not found or didn't match any files)*

------
https://chatgpt.com/codex/tasks/task_e_688df7e17e888325a63d785cb3dacc6c