### PR TITLE
feat: add parameterized translations

### DIFF
--- a/app/components/AboutModal.tsx
+++ b/app/components/AboutModal.tsx
@@ -18,11 +18,11 @@ export default function AboutModal({
   return (
     <Modal show={show} onHide={() => setShow(false)} centered={true}>
       <Modal.Header>
-        <Modal.Title>{t("About {name}").replace("{name}", name)}</Modal.Title>
+        <Modal.Title>{t("About {name}", { name })}</Modal.Title>
       </Modal.Header>
       <Modal.Body>
         <p className="font-monospace">
-          {t("Version {version}").replace("{version}", version)}
+          {t("Version {version}", { version })}
         </p>
         <p>
           ©2020-2025 OpenFusion Contributors

--- a/app/components/DeleteServerModal.tsx
+++ b/app/components/DeleteServerModal.tsx
@@ -23,10 +23,9 @@ export default function DeleteServerModal({
         <Modal.Title>{t("Are you sure?")}</Modal.Title>
       </Modal.Header>
       <Modal.Body>
-        {t("Do you really want to delete {server}?").replace(
-          "{server}",
-          server?.description ?? "",
-        )}
+        {t("Do you really want to delete {server}?", {
+          server: server?.description ?? "",
+        })}
         <br />
         {t("You could always re-add it later.")}
       </Modal.Body>

--- a/app/components/LogoImages.tsx
+++ b/app/components/LogoImages.tsx
@@ -43,7 +43,7 @@ export default function BackgroundImages({
         <img
           src={imageUrl}
           className="logo-image"
-          alt={t("{server} Logo").replace("{server}", selectedServer.description)}
+          alt={t("{server} Logo", { server: selectedServer.description })}
         />
       </div>
     );

--- a/app/components/SelectVersionModal.tsx
+++ b/app/components/SelectVersionModal.tsx
@@ -83,10 +83,8 @@ export default function SelectVersionModal({
         <span
           dangerouslySetInnerHTML={{
             __html: t(
-              "The server {server} supports multiple game versions. Please select a version to use."
-            ).replace(
-              "{server}",
-              `<strong>${server?.description ?? ""}</strong>`
+              "The server {server} supports multiple game versions. Please select a version to use.",
+              { server: `<strong>${server?.description ?? ""}</strong>` },
             ),
           }}
         />

--- a/app/i18n.tsx
+++ b/app/i18n.tsx
@@ -110,5 +110,13 @@ export function useLanguage() {
 
 export function useT() {
   const { translations } = useLanguage();
-  return (key: string) => translations[key] || key;
+  return (key: string, params?: Record<string, string>) => {
+    let text = translations[key] || key;
+    if (params) {
+      for (const [name, value] of Object.entries(params)) {
+        text = text.replace(new RegExp(`\\{${name}\\}`, "g"), value);
+      }
+    }
+    return text;
+  };
 }

--- a/app/settings/AuthenticationTab.tsx
+++ b/app/settings/AuthenticationTab.tsx
@@ -29,10 +29,9 @@ export default function AuthenticationTab({ active }: { active: boolean }) {
     } catch (e) {
       if (ctx.alertError) {
         ctx.alertError(
-          t("Failed to log out of all game servers: {error}").replace(
-            "{error}",
-            "" + e,
-          ),
+          t("Failed to log out of all game servers: {error}", {
+            error: "" + e,
+          }),
         );
       }
     }


### PR DESCRIPTION
## Summary
- support parameter replacement in `useT`
- use new `useT` params across components and settings

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: The system library `gobject-2.0` required by crate `gobject-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e85a5afcc832582dcc3d08706bb74