### PR TITLE
fix: specify language cache type

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -141,7 +141,8 @@ async fn load_language(lang: String) -> CommandResult<HashMap<String, String>> {
     let locales_dir = state::get_app_statics().resource_dir.join("locales");
     let file_path = locales_dir.join(format!("{}.json", lang));
     let contents = std::fs::read_to_string(file_path).map_err(|e| e.to_string())?;
-    let map = serde_json::from_str(&contents).map_err(|e| e.to_string())?;
+    let map: HashMap<String, String> =
+        serde_json::from_str(&contents).map_err(|e| e.to_string())?;
 
     let mut cache_guard = cache.lock().await;
     cache_guard.insert(lang, map.clone());


### PR DESCRIPTION
## Summary
- fix language loading by explicitly deserializing locale JSON into `HashMap<String, String>`

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glob pattern ../resources/ffrunner/mono/fusion-2.x.x/Data/lib/* path not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ea15660f883259ff40449edf10814