### PR TITLE
feat: load dynamic languages

### DIFF
--- a/app/settings/LauncherSettingsTab.tsx
+++ b/app/settings/LauncherSettingsTab.tsx
@@ -6,13 +6,7 @@ import SettingControlBrowse from "./SettingControlBrowse";
 import { getDebugMode } from "@/app/util";
 import { SettingsCtx } from "@/app/contexts";
 import SettingsHeader from "./SettingsHeader";
-import {
-  useT,
-  useLanguage,
-  availableLanguages,
-  languageNames,
-  type Language,
-} from "@/app/i18n";
+import { useT, useLanguage, type Language } from "@/app/i18n";
 
 export default function LauncherSettingsTab({
   active,
@@ -32,7 +26,7 @@ export default function LauncherSettingsTab({
 
   const ctx = useContext(SettingsCtx);
   const t = useT();
-  const { setLang } = useLanguage();
+  const { setLang, availableLanguages, languageNames } = useLanguage();
 
   useEffect(() => {
     getDebugMode().then(setDebug);


### PR DESCRIPTION
## Summary
- provide language list and names through context state
- use context-provided languages in settings

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glob pattern ../resources/ffrunner/mono/fusion-2.x.x/* path not found or didn't match any files)*

------
https://chatgpt.com/codex/tasks/task_e_68923c28a59c83259067d0a960c3f75c