### PR TITLE
Capitalize language names

### DIFF
--- a/app/i18n.tsx
+++ b/app/i18n.tsx
@@ -61,7 +61,7 @@ export function LanguageProvider({ children }: { children: React.ReactNode }) {
         langs.forEach((code) => {
           const name =
             new Intl.DisplayNames([code], { type: "language" }).of(code) || code;
-          names[code] = name;
+          names[code] = name[0].toLocaleUpperCase() + name.slice(1);
         });
         setLanguageNames(names);
         let chosen = "en";


### PR DESCRIPTION
## Summary
- Capitalize language names when building the language lookup

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glob pattern ../resources/ffrunner/player/fusion-2.x.x/Data/lib/* path not found)*

------
https://chatgpt.com/codex/tasks/task_e_68924b781ebc8325bd4e349b5cb28898