### PR TITLE
Load locales directly from bundled resources

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -111,34 +111,14 @@ struct NewServerDetails {
     endpoint: Option<String>,
 }
 
-fn ensure_locales_dir() -> PathBuf {
-    let locales_dir = state::get_app_statics().app_data_dir.join("locales");
-    if let Err(e) = std::fs::create_dir_all(&locales_dir) {
-        warn!("Failed to create locales dir: {}", e);
-    }
-
-    let builtin_dir = state::get_app_statics().resource_dir.join("locales");
-    if let Ok(entries) = std::fs::read_dir(builtin_dir) {
-        for entry in entries.flatten() {
-            let src_path = entry.path();
-            if src_path.extension().and_then(|e| e.to_str()) == Some("json") {
-                let dest_path = locales_dir.join(entry.file_name());
-                if !dest_path.exists() {
-                    if let Err(e) = std::fs::copy(&src_path, &dest_path) {
-                        warn!("Failed to copy locale {:?}: {}", src_path, e);
-                    }
-                }
-            }
-        }
-    }
-
-    locales_dir
+fn get_locales_dir() -> PathBuf {
+    state::get_app_statics().resource_dir.join("locales")
 }
 
 #[tauri::command]
 async fn get_languages() -> CommandResult<Vec<String>> {
     let mut langs = Vec::new();
-    let locales_dir = ensure_locales_dir();
+    let locales_dir = get_locales_dir();
     if let Ok(entries) = std::fs::read_dir(locales_dir) {
         for entry in entries.flatten() {
             let path = entry.path();
@@ -154,8 +134,7 @@ async fn get_languages() -> CommandResult<Vec<String>> {
 
 #[tauri::command]
 async fn load_language(lang: String) -> CommandResult<HashMap<String, String>> {
-    let locales_dir = ensure_locales_dir();
-    let file_path = locales_dir.join(format!("{}.json", lang));
+    let file_path = get_locales_dir().join(format!("{}.json", lang));
     let contents = std::fs::read_to_string(file_path).map_err(|e| e.to_string())?;
     let map = serde_json::from_str(&contents).map_err(|e| e.to_string())?;
     Ok(map)

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -40,7 +40,7 @@
       "../resources/defaults/*": "defaults/",
       "../resources/defaults/versions/*": "defaults/versions/",
       "../resources/assets/img/*": "assets/img/",
-      "../resources/locales/*": "locales/",
+      "../resources/locales/*.json": "locales/",
       "../resources/ffrunner/ffrunner.exe": "ffrunner.exe",
       "../resources/ffrunner/d3d9_vulkan.dll": "d3d9_vulkan.dll",
       "../resources/ffrunner/loader/*": "loader/",


### PR DESCRIPTION
## Summary
- load runtime locale files from bundled `resources/locales`
- bundle all locale JSON files during build

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glob pattern ../resources/ffrunner/mono/fusion-2.x.x/Data/lib/* path not found or didn't match any files)*

------
https://chatgpt.com/codex/tasks/task_e_68925091826c8325ab6ce5e19e1553a5