### PR TITLE
feat: support translation parameters

### DIFF
--- a/app/components/AboutModal.tsx
+++ b/app/components/AboutModal.tsx
@@ -18,11 +18,11 @@ export default function AboutModal({
   return (
     <Modal show={show} onHide={() => setShow(false)} centered={true}>
       <Modal.Header>
-        <Modal.Title>{t("nav.about").replace("{name}", name)}</Modal.Title>
+        <Modal.Title>{t("nav.about", { name })}</Modal.Title>
       </Modal.Header>
       <Modal.Body>
         <p className="font-monospace">
-          {t("common.version").replace("{version}", version)}
+          {t("common.version", { version })}
         </p>
         <p>
           ©2020-2025 OpenFusion Contributors

--- a/app/components/DeleteServerModal.tsx
+++ b/app/components/DeleteServerModal.tsx
@@ -23,10 +23,7 @@ export default function DeleteServerModal({
         <Modal.Title>{t("dialog.sure")}</Modal.Title>
       </Modal.Header>
       <Modal.Body>
-        {t("dialog.confirmDelete").replace(
-          "{server}",
-          server?.description ?? "",
-        )}
+        {t("dialog.confirmDelete", { server: server?.description ?? "" })}
         <br />
         {t("common.alwaysReaddLater")}
       </Modal.Body>

--- a/app/components/LogoImages.tsx
+++ b/app/components/LogoImages.tsx
@@ -43,7 +43,7 @@ export default function BackgroundImages({
         <img
           src={imageUrl}
           className="logo-image"
-          alt={t("server.logo").replace("{server}", selectedServer.description)}
+          alt={t("server.logo", { server: selectedServer.description })}
         />
       </div>
     );

--- a/app/components/SelectVersionModal.tsx
+++ b/app/components/SelectVersionModal.tsx
@@ -82,12 +82,9 @@ export default function SelectVersionModal({
       <Modal.Body>
         <span
           dangerouslySetInnerHTML={{
-            __html: t(
-              "server.supportsMultipleGame"
-            ).replace(
-              "{server}",
-              `<strong>${server?.description ?? ""}</strong>`
-            ),
+            __html: t("server.supportsMultipleGame", {
+              server: `<strong>${server?.description ?? ""}</strong>`,
+            }),
           }}
         />
         <br />

--- a/app/i18n.tsx
+++ b/app/i18n.tsx
@@ -119,5 +119,16 @@ export function useLanguage() {
 
 export function useT() {
   const { translations } = useLanguage();
-  return (key: string) => translations[key] || key;
+  return (
+    key: string,
+    params?: Record<string, string | number>,
+  ): string => {
+    let str = translations[key] || key;
+    if (params) {
+      for (const [placeholder, value] of Object.entries(params)) {
+        str = str.replaceAll(`{${placeholder}}`, String(value));
+      }
+    }
+    return str;
+  };
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -172,10 +172,7 @@ export default function Home() {
       if (updateInfo) {
         setUpdateAvailable(updateInfo);
         alertInfo(
-          t("common.updateAvailable").replace(
-            "{version}",
-            updateInfo.version,
-          ),
+          t("common.updateAvailable", { version: updateInfo.version }),
           updateInfo.url,
         );
       }
@@ -224,10 +221,7 @@ export default function Home() {
       }
     } catch (e: unknown) {
       alertError(
-        t("status.failedImportOpenfusionclient").replace(
-          "{error}",
-          String(e),
-        ),
+        t("status.failedImportOpenfusionclient", { error: String(e) }),
       );
     }
     stopLoading("import");
@@ -282,9 +276,7 @@ export default function Home() {
       await getCurrentWindow().setFocus();
     } catch (e: unknown) {
       await getCurrentWindow().show();
-      alertError(
-        t("status.errorDuringInit").replace("{error}", String(e)),
-      );
+      alertError(t("status.errorDuringInit", { error: String(e) }));
     }
   };
 
@@ -316,9 +308,7 @@ export default function Home() {
       }
     } catch (e: unknown) {
       await getCurrentWindow().show();
-      alertError(
-        t("status.failedLaunch").replace("{error}", String(e)),
-      );
+      alertError(t("status.failedLaunch", { error: String(e) }));
     }
     stopLoading("launch");
   };
@@ -345,7 +335,7 @@ export default function Home() {
         alertInfo(res.resp);
       }
     } catch (e: unknown) {
-      alertError(t("status.failedRegister").replace("{error}", String(e)));
+      alertError(t("status.failedRegister", { error: String(e) }));
     }
     stopLoading("do_register");
   };
@@ -365,7 +355,7 @@ export default function Home() {
         remember: remember,
       });
     } catch (e: unknown) {
-      alertError(t("status.failedLogin").replace("{error}", String(e)));
+      alertError(t("status.failedLogin", { error: String(e) }));
       return;
     } finally {
       stopLoading("do_login");
@@ -412,9 +402,7 @@ export default function Home() {
         });
       } catch (e: unknown) {
         stopLoading("configure_endpoint");
-        alertError(
-          t("status.failedGetVersions").replace("{error}", String(e)),
-        );
+        alertError(t("status.failedGetVersions", { error: String(e) }));
         setConnecting(false);
         return;
       }
@@ -432,12 +420,7 @@ export default function Home() {
         }
       }
 
-      alertSuccess(
-        t("common.logged").replace(
-          "{username}",
-          session.username,
-        ),
-      );
+      alertSuccess(t("common.logged", { username: session.username }));
     }
 
     if (!version) {
@@ -461,9 +444,7 @@ export default function Home() {
       setSelectedServer(uuid);
       alertSuccess(t("server.added"));
     } catch (e: unknown) {
-      alertError(
-        t("server.failedAdd").replace("{error}", String(e)),
-      );
+      alertError(t("server.failedAdd", { error: String(e) }));
     }
     stopLoading("add_server");
   };
@@ -489,9 +470,7 @@ export default function Home() {
         alertSuccess(t("server.updated"));
       }
     } catch (e: unknown) {
-      alertError(
-        t("server.failedUpdate").replace("{error}", String(e)),
-      );
+      alertError(t("server.failedUpdate", { error: String(e) }));
     }
     stopLoading("update_server");
   };
@@ -518,9 +497,7 @@ export default function Home() {
         }
         alertSuccess(t("server.deleted"));
       } catch (e: unknown) {
-        alertError(
-          t("server.failedDelete").replace("{error}", String(e)),
-        );
+        alertError(t("server.failedDelete", { error: String(e) }));
       }
     }
   };
@@ -534,12 +511,7 @@ export default function Home() {
       setShowForgotPasswordModal(false);
       alertSuccess(t("auth.onetimePasswordSent"));
     } catch (e: unknown) {
-      alertError(
-        t("auth.failedSendOnetime").replace(
-          "{error}",
-          String(e),
-        ),
-      );
+      alertError(t("auth.failedSendOnetime", { error: String(e) }));
     }
   };
 

--- a/app/settings/AuthenticationTab.tsx
+++ b/app/settings/AuthenticationTab.tsx
@@ -29,10 +29,7 @@ export default function AuthenticationTab({ active }: { active: boolean }) {
     } catch (e) {
       if (ctx.alertError) {
         ctx.alertError(
-          t("server.failedLogOut").replace(
-            "{error}",
-            "" + e,
-          ),
+          t("server.failedLogOut", { error: String(e) }),
         );
       }
     }


### PR DESCRIPTION
## Summary
- extend translation helper to substitute placeholders with provided params
- refactor components to use `t(key, params)` instead of manual string replacement

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: resource path `../resources/ffrunner/d3d9_vulkan.dll` doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_689366b57d748325be9618a8a0142194