### PR TITLE
feat: fallback to english translations

### DIFF
--- a/app/i18n.tsx
+++ b/app/i18n.tsx
@@ -41,6 +41,11 @@ export function LanguageProvider({ children }: { children: React.ReactNode }) {
 
   const setLang = (newLang: Language) => {
     setLangState(newLang);
+    if (!localeCache["en"]) {
+      loadLocale("en").then((map) => {
+        localeCache["en"] = map;
+      });
+    }
     if (localeCache[newLang]) {
       setTranslations(localeCache[newLang]!);
     } else {
@@ -79,8 +84,12 @@ export function LanguageProvider({ children }: { children: React.ReactNode }) {
             }
           }
         }
+        if (!localeCache["en"]) {
+          localeCache["en"] = await loadLocale("en");
+        }
         if (!localeCache[chosen]) {
-          localeCache[chosen] = await loadLocale(chosen);
+          localeCache[chosen] =
+            chosen === "en" ? localeCache["en"]! : await loadLocale(chosen);
         }
         setTranslations(localeCache[chosen]!);
         setLangState(chosen);
@@ -123,7 +132,8 @@ export function useT() {
     key: string,
     params?: Record<string, string | number>,
   ): string => {
-    let str = translations[key] || key;
+    let str =
+      translations[key] ?? localeCache["en"]?.[key] ?? key;
     if (params) {
       for (const [placeholder, value] of Object.entries(params)) {
         str = str.replaceAll(`{${placeholder}}`, String(value));


### PR DESCRIPTION
## Summary
- load English translations on language change and initialization
- use English locale as fallback when a translation key is missing

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68936aefb4d883258eccf001e0bdd093