### PR TITLE
feat: rename common value key to and

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -208,7 +208,7 @@ export default function Home() {
             counts.version_count > 1 ? t("common.versions") : t("common.version3")
           }`;
           if (counts.server_count > 0) {
-            text += ` ${t("common.value")} `;
+            text += ` ${t("common.and")} `;
           }
         }
         if (counts.server_count > 0) {

--- a/resources/locales/en.json
+++ b/resources/locales/en.json
@@ -145,7 +145,7 @@
   "common.updateAvailable": "Update available: {version}",
   "common.upsell": "Upsell",
   "common.username": "Username",
-  "common.value": "and",
+  "common.and": "and",
   "common.verificationEmailSent": "Verification email sent to {email}",
   "common.version": "Version {version}",
   "common.version2": "Version",

--- a/resources/locales/fr.json
+++ b/resources/locales/fr.json
@@ -145,7 +145,7 @@
   "common.updateAvailable": "Mise à jour disponible: {version}",
   "common.upsell": "Cochette",
   "common.username": "Nom d'utilisateur",
-  "common.value": "et",
+  "common.and": "et",
   "common.verificationEmailSent": "Email de vérification envoyé à {email}",
   "common.version": "Version {version}",
   "common.version2": "Version",

--- a/resources/locales/ru.json
+++ b/resources/locales/ru.json
@@ -145,7 +145,7 @@
   "common.updateAvailable": "Доступно обновление: {version}",
   "common.upsell": "Реклама",
   "common.username": "Имя пользователя",
-  "common.value": "и",
+  "common.and": "и",
   "common.verificationEmailSent": "Письмо для подтверждения отправлено на {email}",
   "common.version": "Версия {version}",
   "common.version2": "Версия",


### PR DESCRIPTION
## Summary
- rename translation key `common.value` to `common.and`
- update import success message to use `common.and`

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glob pattern ../resources/ffrunner/mono/fusion-2.x.x/Data/etc/mono/2.0/* path not found)*

------
https://chatgpt.com/codex/tasks/task_e_689375be86608325a7f02dd334b40a2b