### PR TITLE
Fix success alert language after changing settings

### DIFF
--- a/app/i18n.tsx
+++ b/app/i18n.tsx
@@ -181,3 +181,26 @@ export function useT() {
     return str;
   };
 }
+
+export async function tForLang(
+  lang: Language,
+  key: string,
+  params?: Record<string, string | number>,
+): Promise<string> {
+  if (!localeCache[lang]) {
+    try {
+      const map = await loadLocale(lang);
+      localeCache[lang] = map;
+    } catch (err) {
+      console.error(err);
+      localeCache[lang] = localeCache["en"] ?? {};
+    }
+  }
+  let str = localeCache[lang]?.[key] ?? localeCache["en"]?.[key] ?? key;
+  if (params) {
+    for (const [placeholder, value] of Object.entries(params)) {
+      str = str.replaceAll(`{${placeholder}}`, String(value));
+    }
+  }
+  return str;
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -21,7 +21,7 @@ import { getTheme } from "@/app/util";
 import AuthenticationTab from "./AuthenticationTab";
 import LauncherSettingsTab from "./LauncherSettingsTab";
 import GameSettingsTab from "./GameSettingsTab";
-import { useT, useLanguage, type Language } from "@/app/i18n";
+import { useT, useLanguage, type Language, tForLang } from "@/app/i18n";
 
 const TAB_LAUNCHER_SETTINGS = "launcher-settings";
 const TAB_GAME_SETTINGS = "game-settings";
@@ -162,7 +162,11 @@ export default function SettingsPage() {
       const newConfig = { ...config!, launcher: newSettings };
       await saveConfig(newConfig);
       const updatedConfig = await syncConfig();
-      alertSuccess(t("status.changesAppliedSuccessfully"));
+      const successMsg = await tForLang(
+        updatedConfig.launcher.language as Language,
+        "status.changesAppliedSuccessfully",
+      );
+      alertSuccess(successMsg);
       return updatedConfig.launcher;
     } else {
       await resetLauncherSettings();
@@ -176,7 +180,11 @@ export default function SettingsPage() {
       const newConfig = { ...config!, game: newSettings };
       await saveConfig(newConfig);
       const updatedConfig = await syncConfig();
-      alertSuccess(t("status.changesAppliedSuccessfully"));
+      const successMsg = await tForLang(
+        updatedConfig.launcher.language as Language,
+        "status.changesAppliedSuccessfully",
+      );
+      alertSuccess(successMsg);
       return updatedConfig.game;
     } else {
       await resetGameSettings();


### PR DESCRIPTION
## Summary
- load locale for a specific language via new `tForLang` helper
- ensure settings updates show success message in the newly selected language

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glob pattern ../resources/ffrunner/player/fusion-2.x.x/* path not found)*

------
https://chatgpt.com/codex/tasks/task_e_68939c11b7648325aab5e40eb32505b6