### PR TITLE
feat: load localized images

### DIFF
--- a/app/components/LoadingScreen.tsx
+++ b/app/components/LoadingScreen.tsx
@@ -1,13 +1,20 @@
 import { LoadingTask } from "@/app/types";
 import Spinner from "react-bootstrap/Spinner";
 import Stack from "react-bootstrap/Stack";
+import LocalizedImage from "@/components/LocalizedImage";
 
 export default function LoadingScreen({ tasks }: { tasks: LoadingTask[] }) {
   return (
     <>
       <div id="loading-screen">
         <div className="loading-screen-component" id="loading-screen-bg"></div>
-        <Stack className="loading-screen-component d-flex align-items-center justify-content-center">
+        <Stack className="loading-screen-component d-flex align-items-center justify-content-center" gap={2}>
+          <LocalizedImage
+            src="assets/img/unity-dexlabs.png"
+            alt="DexLabs logo"
+            width={256}
+            className="mb-3"
+          />
           <Spinner animation="border" role="status" />
           {tasks.map((task) => (
             <span key={task.id}>{task.text}</span>

--- a/app/components/LocalizedImage.tsx
+++ b/app/components/LocalizedImage.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+import { useLanguage } from "@/app/i18n";
+
+interface LocalizedImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
+  src: string;
+}
+
+export default function LocalizedImage({ src, ...props }: LocalizedImageProps) {
+  const { lang } = useLanguage();
+  const [currentSrc, setCurrentSrc] = useState(src);
+
+  useEffect(() => {
+    const dotIndex = src.lastIndexOf(".");
+    const localizedSrc =
+      dotIndex >= 0
+        ? `${src.slice(0, dotIndex)}-${lang}${src.slice(dotIndex)}`
+        : `${src}-${lang}`;
+    setCurrentSrc(src);
+    const img = new Image();
+    img.onload = () => setCurrentSrc(localizedSrc);
+    img.onerror = () => setCurrentSrc(src);
+    img.src = localizedSrc;
+  }, [lang, src]);
+
+  return <img src={currentSrc} {...props} />;
+}


### PR DESCRIPTION
## Summary
- show a localized DexLabs logo on the loading screen
- add LocalizedImage helper for language-aware image loading

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_6893a3dd356c8325905157182ed261c3