### PR TITLE
Fix localized logo swap

### DIFF
--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -30,7 +30,6 @@ pub fn get_app_statics() -> &'static AppStatics {
 pub struct LogoSwap {
     pub img_dir: PathBuf,
     pub backup: PathBuf,
-    pub localized: PathBuf,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
## Summary
- swap unity-dexlabs logo using file copies to respect selected language

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: resource path `../resources/ffrunner/d3d9_vulkan.dll` doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_6893c739d9888325977f9c337d959703