### PR TITLE
Restore default logo if ffrunner launch fails

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -161,9 +161,15 @@ async fn do_launch(app_handle: tauri::AppHandle) -> CommandResult<i32> {
     let cmd_str = util::get_launch_cmd_dbg_str(&cmd, false);
     drop(state);
 
-    let mut proc = cmd
-        .spawn()
-        .map_err(|e| format!("{} (launch command was: {})", e, cmd_str))?;
+    let mut proc = match cmd.spawn() {
+        Ok(proc) => proc,
+        Err(e) => {
+            if let Some(ls) = logo_swap {
+                restore_logo(ls);
+            }
+            return Err(format!("{} (launch command was: {})", e, cmd_str));
+        }
+    };
     if launch_behavior == LaunchBehavior::Quit {
         if let Some(ls) = logo_swap {
             std::thread::spawn(move || {


### PR DESCRIPTION
## Summary
- ensure unity logo backup is restored when ffrunner fails to spawn

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_6893cdc667b883258e7844022c9846ae