### PR TITLE
refactor: centralize translation formatting

### DIFF
--- a/app/i18n.tsx
+++ b/app/i18n.tsx
@@ -168,21 +168,26 @@ export function useLanguage() {
   return useContext(LangCtx);
 }
 
+function formatTranslation(
+  map: Record<string, string>,
+  key: string,
+  params?: Record<string, string | number>,
+): string {
+  let str = map[key] ?? localeCache["en"]?.[key] ?? key;
+  if (params) {
+    for (const [placeholder, value] of Object.entries(params)) {
+      str = str.replaceAll(`{${placeholder}}`, String(value));
+    }
+  }
+  return str;
+}
+
 export function useT() {
   const { translations } = useLanguage();
   return (
     key: string,
     params?: Record<string, string | number>,
-  ): string => {
-    let str =
-      translations[key] ?? localeCache["en"]?.[key] ?? key;
-    if (params) {
-      for (const [placeholder, value] of Object.entries(params)) {
-        str = str.replaceAll(`{${placeholder}}`, String(value));
-      }
-    }
-    return str;
-  };
+  ): string => formatTranslation(translations, key, params);
 }
 
 export async function tForLang(
@@ -199,11 +204,5 @@ export async function tForLang(
       localeCache[lang] = localeCache["en"] ?? {};
     }
   }
-  let str = localeCache[lang]?.[key] ?? localeCache["en"]?.[key] ?? key;
-  if (params) {
-    for (const [placeholder, value] of Object.entries(params)) {
-      str = str.replaceAll(`{${placeholder}}`, String(value));
-    }
-  }
-  return str;
+  return formatTranslation(localeCache[lang]!, key, params);
 }


### PR DESCRIPTION
## Summary
- centralize translation lookup and placeholder replacement with `formatTranslation`
- use `formatTranslation` in `useT` and `tForLang`

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glob pattern ../resources/ffrunner/mono/fusion-2.x.x/* path not found or didn't match any files)*

------
https://chatgpt.com/codex/tasks/task_e_6893e400c4d08325aa1f1709c27c06bb