### PR TITLE
Avoid blocking read when loading language files

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -135,7 +135,10 @@ async fn get_languages() -> CommandResult<Vec<String>> {
 #[tauri::command]
 async fn load_language(lang: String) -> CommandResult<HashMap<String, String>> {
     let file_path = get_locales_dir().join(format!("{}.json", lang));
-    let contents = std::fs::read_to_string(file_path).map_err(|e| e.to_string())?;
+    let contents = tauri::async_runtime::spawn_blocking(move || std::fs::read_to_string(file_path))
+        .await
+        .map_err(|e| e.to_string())?
+        .map_err(|e| e.to_string())?;
     let map = serde_json::from_str(&contents).map_err(|e| e.to_string())?;
     Ok(map)
 }


### PR DESCRIPTION
## Summary
- wrap language file loading in `tauri::async_runtime::spawn_blocking` to avoid blocking the async runtime

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glob pattern ... Data/lib/* path not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893e924014c8325ba248c0152405e8c