### PR TITLE
refactor: memoize language setter

### DIFF
--- a/app/i18n.tsx
+++ b/app/i18n.tsx
@@ -6,6 +6,7 @@ import {
   useEffect,
   useLayoutEffect,
   useRef,
+  useCallback,
 } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { once, type UnlistenFn } from "@tauri-apps/api/event";
@@ -51,7 +52,7 @@ export function LanguageProvider({ children }: { children: React.ReactNode }) {
 
   const latestRequest = useRef<Language>(lang);
 
-  const setLang = (newLang: Language) => {
+  const setLang = useCallback((newLang: Language) => {
     latestRequest.current = newLang;
     setLangState(newLang);
     fetchLocale("en").catch((err) => {
@@ -82,7 +83,7 @@ export function LanguageProvider({ children }: { children: React.ReactNode }) {
         }
       }
     })();
-  };
+  }, [lang]);
 
   useEffect(() => {
     let unlisten: UnlistenFn | undefined;


### PR DESCRIPTION
## Summary
- memoize language setter with `useCallback`

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glob pattern ../resources/ffrunner/player/fusion-2.x.x/Data/lib/* path not found)*

------
https://chatgpt.com/codex/tasks/task_e_68947dc646288325a3cc6f364917e98c