### PR TITLE
Localize Remove Build modal strings

### DIFF
--- a/app/settings/RemoveBuildModal.tsx
+++ b/app/settings/RemoveBuildModal.tsx
@@ -1,6 +1,7 @@
 import { Modal } from "react-bootstrap";
 import Button from "@/components/Button";
 import { VersionEntry } from "@/app/types";
+import { useT } from "@/app/i18n";
 
 export default function RemoveBuildModal({
   show,
@@ -13,15 +14,21 @@ export default function RemoveBuildModal({
   version?: VersionEntry,
   onConfirm: (uuid: string, deleteCaches: boolean) => void;
 }) {
+  const t = useT();
 
   return (
     <Modal show={show} onHide={() => setShow(false)} centered>
       <Modal.Header closeButton>
-        <Modal.Title>Remove Build</Modal.Title>
+        <Modal.Title>{t("build.remove")}</Modal.Title>
       </Modal.Header>
       <Modal.Body>
-        Are you sure you want to remove build <strong>{version?.name ?? version?.uuid}</strong>?
-        It will be automatically fetched again if it is required by a server.
+        <span
+          dangerouslySetInnerHTML={{
+            __html: t("build.confirmRemove", {
+              build: `<strong>${version?.name ?? version?.uuid}</strong>`,
+            }),
+          }}
+        />
       </Modal.Body>
       <Modal.Footer>
         <Button

--- a/app/translation-key.ts
+++ b/app/translation-key.ts
@@ -27,6 +27,7 @@ export type TranslationKey =
   | 'build.assetUrl'
   | 'build.assetUrlExample'
   | 'build.cannotRemoveDefault'
+  | 'build.confirmRemove'
   | 'build.failedAdd'
   | 'build.failedImport'
   | 'build.failedRemove'

--- a/resources/locales/en.json
+++ b/resources/locales/en.json
@@ -25,6 +25,7 @@
   "build.assetUrl": "Asset URL",
   "build.assetUrlExample": "https://cdn.example.com/build",
   "build.cannotRemoveDefault": "Cannot remove default build",
+  "build.confirmRemove": "Are you sure you want to remove build {build}? It will be automatically fetched again if it is required by a server.",
   "build.failedAdd": "Failed to add build: {error}",
   "build.failedImport": "Failed to import build: {error}",
   "build.failedRemove": "Failed to remove build: {error}",

--- a/resources/locales/fr.json
+++ b/resources/locales/fr.json
@@ -25,6 +25,7 @@
   "build.assetUrl": "URL de ressource",
   "build.assetUrlExample": "https://cdn.example.com/build",
   "build.cannotRemoveDefault": "Impossible de supprimer la construction par défaut",
+  "build.confirmRemove": "Êtes-vous sûr de vouloir supprimer la construction {build}? Elle sera automatiquement récupérée si un serveur en a besoin.",
   "build.failedAdd": "Échec de l'ajout de construction: {error}",
   "build.failedImport": "Échec de l'importation de construction: {error}",
   "build.failedRemove": "Échec de la suppression de la construction: {error}",

--- a/resources/locales/ru.json
+++ b/resources/locales/ru.json
@@ -25,6 +25,7 @@
   "build.assetUrl": "URL ресурса",
   "build.assetUrlExample": "https://cdn.example.com/build",
   "build.cannotRemoveDefault": "Нельзя удалить стандартную сборку",
+  "build.confirmRemove": "Вы уверены, что хотите удалить сборку {build}? Она будет автоматически загружена снова, если потребуется серверу.",
   "build.failedAdd": "Не удалось добавить сборку: {error}",
   "build.failedImport": "Не удалось импортировать сборку: {error}",
   "build.failedRemove": "Не удалось удалить сборку: {error}",


### PR DESCRIPTION
## Summary
- use translation hook for Remove Build modal
- add `build.confirmRemove` to all locales and regenerate translation-key

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68974598ea608325bb98bd8078d6c237