### PR TITLE
fix Russian offline cache deletion translation

### DIFF
--- a/resources/locales/ru.json
+++ b/resources/locales/ru.json
@@ -59,7 +59,7 @@
   "cache.gamePath": "Путь кэша игры",
   "cache.offline": "Офлайн-кэш",
   "cache.offlineDeletedSuccessfully": "Офлайн-кэш для {name} успешно удален",
-  "cache.offlineDeletedSuccessfully2": "Офлайн-кэш успешно удален",
+  "cache.offlineDeletedSuccessfully2": "Офлайн-кэш успешно удалён",
   "cache.offlinePath": "Путь офлайн-кэша",
   "cache.offlineRepairStarted": "Начато восстановление офлайн-кэша",
   "cache.openGameFolder": "Открыть папку кэша игры",


### PR DESCRIPTION
## Summary
- fix Russian offline cache deletion message

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glob pattern ../resources/ffrunner/mono/fusion-2.x.x/* path not found)*

------
https://chatgpt.com/codex/tasks/task_e_68974cf93960832581f403c3502c1949