### PR TITLE
feat: set html language dynamically

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import "@fortawesome/fontawesome-free/css/all.css";
 import "./css/bootstrap.scss";
 import "./css/openfusion-behavior.scss";
@@ -6,13 +8,25 @@ import "./css/openfusion-theming.scss";
 import TitleBar from "./components/TitleBar";
 import { LanguageProvider } from "./i18n";
 
+function getInitialLang(): string {
+  if (typeof window !== "undefined") {
+    const stored = window.localStorage.getItem("lang");
+    if (stored) {
+      return stored;
+    }
+  }
+  return "en";
+}
+
 export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const lang = getInitialLang();
+
   return (
-    <html lang="en" data-bs-theme="dark">
+    <html lang={lang} data-bs-theme="dark">
       <body>
         <LanguageProvider>
           <TitleBar />


### PR DESCRIPTION
## Summary
- set initial `<html>` lang attribute from stored setting

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glob pattern ../resources/ffrunner/mono/fusion-2.x.x/Data/lib/* path not found)*

------
https://chatgpt.com/codex/tasks/task_e_689760ce0d48832592dc97fa798fe30e