### PR TITLE
fix: update Russian confirm translation

### DIFF
--- a/resources/locales/ru.json
+++ b/resources/locales/ru.json
@@ -83,7 +83,7 @@
   "common.clear": "Очистить",
   "common.clearAll": "Очистить всё",
   "common.clearGame": "Очистить игру",
-  "common.confirm": "Подтверждение",
+  "common.confirm": "Подтвердить",
   "common.confirmNewEmail": "Подтвердите новый email",
   "common.cookieExpiredTry": "Срок действия cookie истёк; попробуйте синхронизировать системные часы",
   "common.currentEmail": "Текущий email",


### PR DESCRIPTION
## Summary
- translate `common.confirm` in Russian locale as "Подтвердить"

## Testing
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glob pattern ../resources/ffrunner/mono/fusion-2.x.x/Data/etc/mono/2.0/* path not found or didn't match any files)*

------
https://chatgpt.com/codex/tasks/task_e_689786fb1f6c8325a4909d99e7c081f1